### PR TITLE
[BREAKING] Rename truncation strategy to deletion.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,39 +19,11 @@ end
 
 ## Supported Strategies
 
-<table>
-  <tbody>
-    <tr>
-      <th>Truncation</th>
-      <th>Transaction</th>
-      <th>Deletion</th>
-    </tr>
-    <tr>
-      <td> <b>Yes</b></td>
-      <td> No</td>
-      <td> No</td>
-    </tr>
-  </tbody>
-</table>
-
-(Default strategy is denoted in bold)
+The mongo adapter only has one strategy: the deletion strategy.
 
 ## Configuration options
 
-<table>
-  <tbody>
-    <tr>
-      <th>ORM</th>
-      <th>How to access</th>
-      <th>Notes</th>
-    </tr>
-    <tr>
-      <td> Mongo</td>
-      <td> <code>DatabaseCleaner[:mongo]</code></td>
-      <td> </td>
-    </tr>
-  </tbody>
-</table>
+The deletion strategy has no options.
 
 ## COPYRIGHT
 

--- a/lib/database_cleaner/mongo.rb
+++ b/lib/database_cleaner/mongo.rb
@@ -1,5 +1,5 @@
 require 'database_cleaner/mongo/version'
 require 'database_cleaner/core'
-require 'database_cleaner/mongo/truncation'
+require 'database_cleaner/mongo/deletion'
 
-DatabaseCleaner[:mongo].strategy = :truncation
+DatabaseCleaner[:mongo].strategy = :deletion

--- a/lib/database_cleaner/mongo/deletion.rb
+++ b/lib/database_cleaner/mongo/deletion.rb
@@ -4,7 +4,7 @@ require 'mongo'
 
 module DatabaseCleaner
   module Mongo
-    class Truncation < Strategy
+    class Deletion < Strategy
       def initialize only: [], except: [], cache_tables: nil
         @only = only
         @except = except

--- a/spec/database_cleaner/mongo/deletion_spec.rb
+++ b/spec/database_cleaner/mongo/deletion_spec.rb
@@ -1,7 +1,7 @@
-require 'database_cleaner/mongo/truncation'
+require 'database_cleaner/mongo/deletion'
 require './spec/support/database_helper'
 
-RSpec.describe DatabaseCleaner::Mongo::Truncation do
+RSpec.describe DatabaseCleaner::Mongo::Deletion do
   let(:helper) { DatabaseHelper.new }
 
   around do |example|
@@ -19,7 +19,7 @@ RSpec.describe DatabaseCleaner::Mongo::Truncation do
   end
 
   context "by default" do
-    it "truncates all collections" do
+    it "deletes all collections" do
       expect { subject.clean }.to change {
         [Widget.count, Gadget.count]
       }.from([1,1]).to([0,0])
@@ -29,7 +29,7 @@ RSpec.describe DatabaseCleaner::Mongo::Truncation do
   context "when collections are provided to the :only option" do
     subject { described_class.new(only: ['Widget']) }
 
-    it "only truncates the specified collections" do
+    it "only deletes the specified collections" do
       expect { subject.clean }.to change {
         [Widget.count, Gadget.count]
       }.from([1,1]).to([0,1])
@@ -39,7 +39,7 @@ RSpec.describe DatabaseCleaner::Mongo::Truncation do
   context "when collections are provided to the :except option" do
     subject { described_class.new(except: ['Widget']) }
 
-    it "truncates all but the specified collections" do
+    it "deletes all but the specified collections" do
       expect { subject.clean }.to change {
         [Widget.count, Gadget.count]
       }.from([1,1]).to([1,0])
@@ -53,7 +53,7 @@ RSpec.describe DatabaseCleaner::Mongo::Truncation do
       Gizmo.new(name: 'some gizmo').save!
     end
 
-    it "truncates new collection" do
+    it "deletes new collection" do
       expect { subject.clean }.to change {
         Gizmo.count
       }.from(1).to(0)


### PR DESCRIPTION
MongoDB doesn't have a truncate command, and the MongoDB command actually being invoked here on the database is named `deleteMany`, so I think this makes sense.

Will need to add deprecation warnings to 1.99 for this transition.

Also, I fixed up the configuration docs in the README while I was at it.